### PR TITLE
Setup sassdoc parser environment properly

### DIFF
--- a/lib/sassdoc-data.js
+++ b/lib/sassdoc-data.js
@@ -7,7 +7,10 @@ const sassdocData = function() {
     }
     for (const file in files) {
       const sass = files[file].contents.toString()
-      const sassdocParser = new sassdoc.Parser({}, [/*add annotation handlers here*/])
+
+      let env = {}
+      env = sassdoc.ensureEnvironment(env)
+      const sassdocParser = new sassdoc.Parser(env, [/*add annotation handlers here*/])
 
       const fileComments = sassdocParser.parse(sass)
 


### PR DESCRIPTION
This fixes a build failure when using unknown annotations in sassdoc
