### PR TITLE
Hide horizontally overflowing header content

### DIFF
--- a/scss/style/_header.scss
+++ b/scss/style/_header.scss
@@ -16,6 +16,7 @@ $header-search-lg-width: 500px;
   border-top: 2px solid $color-dark-indigo;
   transition: background-color $transition-normal $transition-ease;
   z-index: $z-index-header;
+  overflow-x: hidden;
 
   &.transparent {
     background-color: transparent;


### PR DESCRIPTION
This is in order to fix glitches when the header is wrongly used with the `container` (instead of `container-fluid`) and a left side nav layout.