### PR TITLE
Simplify the header code snippets

### DIFF
--- a/docs/components/header/index.hbs
+++ b/docs/components/header/index.hbs
@@ -32,13 +32,18 @@ toc:
 
     <p>This is the example standard-colored header using most of
     the possible components.</p>
-    
+
     {{> example path="/components/header/demos/standard-header.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/standard-header"}}
-        {{{.}}}
-      {{/get}}
+      <header class="header">
+        <div class="header-meta hidden-md-down">
+          <!-- items for the upper header part -->
+        </div>
+        <div class="header-main">
+          <!-- items for the main header part -->
+        </div>
+      </header>
     {{/code-snippet}}
 
     <h2 id="supported-content" class="docs-h3">Supported Content</h2>
@@ -71,9 +76,14 @@ toc:
     {{> example path="/components/header/demos/meta-menu.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/meta-menu"}}
-        {{{.}}}
-      {{/get}}
+      <nav class="header-meta-menu">
+        <ul class="header-meta-menu-list">
+          <li class="header-meta-menu-item">
+            <a href="#" class="header-meta-menu-link">Individuals</a>
+          </li>
+          <!-- more items -->
+        </ul>
+      </nav>
     {{/code-snippet}}
 
     <h3 class="docs-h4">Brand</h3>
@@ -87,11 +97,15 @@ toc:
     {{> example path="/components/header/demos/brand.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/brand"}}
-        {{{.}}}
-      {{/get}}
+      <a href="#" class="header-brand">
+        <span>
+          <strong>AXA</strong>
+          <br />
+          <span>Strategic Ventures</span>
+        </span>
+      </a>
     {{/code-snippet}}
-    
+
     <p>You can also provide an image like a logo by simply replacing
     any text and adding an image to the <code>.header-brand</code>
     item.</p>
@@ -99,9 +113,9 @@ toc:
     {{> example path="/components/header/demos/brand-image.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/brand-image"}}
-        {{{.}}}
-      {{/get}}
+      <a href="#" class="header-brand">
+        <img class="header-brand-image" src="axa.svg" />
+      </a>
     {{/code-snippet}}
 
     <h3 class="docs-h4">Burger</h3>
@@ -112,12 +126,12 @@ toc:
     sure it is placed correctly on the side where the drawer is
     going to appear.</p>
 
-    {{> example path="/components/header/demos/brand-image.html"}}
+    {{> example path="/components/header/demos/burger.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/brand-image"}}
-        {{{.}}}
-      {{/get}}
+      <a href="#" class="header-burger">
+        <span class="header-burger-line"></span>
+      </a>
     {{/code-snippet}}
 
     <h3 class="docs-h4">Search</h3>
@@ -129,9 +143,15 @@ toc:
     {{> example path="/components/header/demos/search.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/search"}}
-        {{{.}}}
-      {{/get}}
+      <form class="header-search float-xs-right" data-search="header">
+        <div class="header-search-dunno">
+          <input type="text" class="header-search-input" name="q" placeholder="Search the entire axa.com" />
+          <button type="submit" class="header-search-button">
+            <span class="sr-only">Search</span>
+            <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+          </button>
+        </div>
+      </form>
     {{/code-snippet}}
 
     <h3 class="docs-h4">Navigation</h3>
@@ -142,9 +162,15 @@ toc:
     {{> example path="/components/header/demos/navigation.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/navigation"}}
-        {{{.}}}
-      {{/get}}
+    <nav id="demoNav" class="nav">
+      <ul class="nav-list">
+        <li class="nav-item">
+          <a href="#" class="nav-link">Web Guidelines</a>
+        </li>
+        <!-- more items -->
+      </ul>
+      <div class="nav-stroke" data-spy="stroke" data-target="#demoNav" />
+    </nav>
     {{/code-snippet}}
 
     <h3 class="docs-h4">All other items</h3>
@@ -156,9 +182,9 @@ toc:
     {{> example path="/components/header/demos/custom-items.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/custom-items"}}
-        {{{.}}}
-      {{/get}}
+      <div class="header-item">
+        <a href="#" class="btn btn-default">File a Claim</a>
+      </div>
     {{/code-snippet}}
 
     <h2 id="positioning-content" class="docs-h3">Positioning content</h2>
@@ -219,9 +245,9 @@ toc:
     {{> example path="/components/header/demos/transparent-header.html"}}
 
     {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/transparent-header"}}
-        {{{.}}}
-      {{/get}}
+      <header class="header transparent">
+        <!-- header content -->
+      </header>
     {{/code-snippet}}
 
   {{/inline}}

--- a/docs/components/header/snippets/brand-image.hbs
+++ b/docs/components/header/snippets/brand-image.hbs
@@ -4,10 +4,8 @@ layout: demo.hbs
 ---
 <header class="header">
   <div class="header-main">
-    <div class="container-fluid">
-      <a href="#" class="header-brand">
-        <img class="header-brand-image" src="{{relative '/images/axa.svg'}}" />
-      </a>
-    </div>
+    <a href="#" class="header-brand">
+      <img class="header-brand-image" src="{{relative '/images/axa.svg'}}" />
+    </a>
   </div>
 </header>

--- a/docs/components/header/snippets/brand.hbs
+++ b/docs/components/header/snippets/brand.hbs
@@ -4,14 +4,12 @@ layout: demo.hbs
 ---
 <header class="header">
   <div class="header-main">
-    <div class="container-fluid">
-      <a href="#" class="header-brand">
-        <span>
-          <strong>AXA</strong>
-          <br />
-          <span>Strategic Ventures</span>
-        </span>
-      </a>
-    </div>
+    <a href="#" class="header-brand">
+      <span>
+        <strong>AXA</strong>
+        <br />
+        <span>Strategic Ventures</span>
+      </span>
+    </a>
   </div>
 </header>

--- a/docs/components/header/snippets/burger.hbs
+++ b/docs/components/header/snippets/burger.hbs
@@ -4,10 +4,8 @@ layout: demo.hbs
 ---
 <header class="header">
   <div class="header-main">
-    <div class="container-fluid">
-      <a href="#" class="header-burger">
-        <span class="header-burger-line"></span>
-      </a>
-    </div>
+    <a href="#" class="header-burger">
+      <span class="header-burger-line"></span>
+    </a>
   </div>
 </header>

--- a/docs/components/header/snippets/custom-items.hbs
+++ b/docs/components/header/snippets/custom-items.hbs
@@ -4,10 +4,8 @@ layout: demo.hbs
 ---
 <header class="header">
   <div class="header-main">
-    <div class="container-fluid">
-      <div class="header-item">
-        <a href="#" class="btn btn-default">File a Claim</a>
-      </div>
+    <div class="header-item">
+      <a href="#" class="btn btn-default">File a Claim</a>
     </div>
   </div>
 </header>

--- a/docs/components/header/snippets/meta-menu.hbs
+++ b/docs/components/header/snippets/meta-menu.hbs
@@ -4,20 +4,18 @@ layout: demo.hbs
 ---
 <header class="header">
   <div class="header-meta">
-    <div class="container-fluid">
-      <nav class="header-meta-menu">
-        <ul class="header-meta-menu-list">
-          <li class="header-meta-menu-item">
-            <a href="#" class="header-meta-menu-link">Individuals</a>
-          </li>
-          <li class="header-meta-menu-item">
-            <a href="#" class="header-meta-menu-link">Small Businesses</a>
-          </li>
-          <li class="header-meta-menu-item">
-            <a href="#" class="header-meta-menu-link">Businesses</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
+    <nav class="header-meta-menu">
+      <ul class="header-meta-menu-list">
+        <li class="header-meta-menu-item">
+          <a href="#" class="header-meta-menu-link">Individuals</a>
+        </li>
+        <li class="header-meta-menu-item">
+          <a href="#" class="header-meta-menu-link">Small Businesses</a>
+        </li>
+        <li class="header-meta-menu-item">
+          <a href="#" class="header-meta-menu-link">Businesses</a>
+        </li>
+      </ul>
+    </nav>
   </div>
 </header>

--- a/docs/components/header/snippets/navigation.hbs
+++ b/docs/components/header/snippets/navigation.hbs
@@ -4,18 +4,16 @@ layout: demo.hbs
 ---
 <header class="header">
   <div class="header-main">
-    <div class="container-fluid">
-      <nav id="demoNav" class="nav">
-        <ul class="nav-list">
-          <li class="nav-item">
-            <a href="#" class="nav-link">Web Guidelines</a>
-          </li>
-          <li class="nav-item">
-            <a href="#" class="nav-link">Toolkit</a>
-          </li>
-        </ul>
-        <div class="nav-stroke" data-spy="stroke" data-target="#demoNav" />
-      </nav>
-    </div>
+    <nav id="demoNav" class="nav">
+      <ul class="nav-list">
+        <li class="nav-item">
+          <a href="#" class="nav-link">Web Guidelines</a>
+        </li>
+        <li class="nav-item">
+          <a href="#" class="nav-link">Toolkit</a>
+        </li>
+      </ul>
+      <div class="nav-stroke" data-spy="stroke" data-target="#demoNav" />
+    </nav>
   </div>
 </header>

--- a/docs/components/header/snippets/search.hbs
+++ b/docs/components/header/snippets/search.hbs
@@ -4,16 +4,14 @@ layout: demo.hbs
 ---
 <header class="header">
   <div class="header-main">
-    <div class="container-fluid">
-      <form class="header-search float-xs-right" data-search="header">
-        <div class="header-search-dunno">
-          <input type="text" class="header-search-input" name="q" placeholder="Search the entire axa.com" />
-          <button type="submit" class="header-search-button">
-            <span class="sr-only">Search</span>
-            <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
-          </button>
-        </div>
-      </form>
-    </div>
+    <form class="header-search float-xs-right" data-search="header">
+      <div class="header-search-dunno">
+        <input type="text" class="header-search-input" name="q" placeholder="Search the entire axa.com" />
+        <button type="submit" class="header-search-button">
+          <span class="sr-only">Search</span>
+          <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+        </button>
+      </div>
+    </form>
   </div>
 </header>


### PR DESCRIPTION
Simplify the header code snippets, by not showing the whole markup of everything.

Also removed the `container` from the header item docs. How to use a container is described later on.