### PR TITLE
Fix issues with indentation in code samples

### DIFF
--- a/docs/components/buttons/index.hbs
+++ b/docs/components/buttons/index.hbs
@@ -55,11 +55,7 @@ toc:
     </p>
 
     {{> example path="/components/buttons/demos/standard-button.html"}}
-    {{#code-snippet "html"}}
-      {{#get snippets "/components/buttons/snippets/standard-button"}}
-        {{{.}}}
-      {{/get}}
-    {{/code-snippet}}
+    {{#code-snippet "html"}}{{#get snippets "/components/buttons/snippets/standard-button"}}{{{.}}}{{/get}}{{/code-snippet}}
 
     <h2 class="h3" id="icon-buttons">Icon button</h2>
     <p>
@@ -68,11 +64,7 @@ toc:
     </p>
 
     {{> example path="/components/buttons/demos/icon-button.html"}}
-    {{#code-snippet "html"}}
-      {{#get snippets "/components/buttons/snippets/icon-button"}}
-        {{{.}}}
-      {{/get}}
-    {{/code-snippet}}
+    {{#code-snippet "html"}}{{#get snippets "/components/buttons/snippets/icon-button"}}{{{.}}}{{/get}}{{/code-snippet}}
 
     <h2 class="h3" id="axa-buttons">AXA button</h2>
     <p>
@@ -81,11 +73,7 @@ toc:
     </p>
 
     {{> example path="/components/buttons/demos/axa-button.html"}}
-    {{#code-snippet "html"}}
-      {{#get snippets "/components/buttons/snippets/axa-button"}}
-        {{{.}}}
-      {{/get}}
-    {{/code-snippet}}
+    {{#code-snippet "html"}}{{#get snippets "/components/buttons/snippets/axa-button"}}{{{.}}}{{/get}}{{/code-snippet}}
 
     <h2 class="h3" id="ghost-buttons">Ghost button</h2>
     <p>
@@ -94,10 +82,6 @@ toc:
     </p>
 
     {{> example path="/components/buttons/demos/ghost-button.html"}}
-    {{#code-snippet "html"}}
-      {{#get snippets "/components/buttons/snippets/ghost-button"}}
-        {{{.}}}
-      {{/get}}
-    {{/code-snippet}}
+    {{#code-snippet "html"}}{{#get snippets "/components/buttons/snippets/ghost-button"}}{{{.}}}{{/get}}{{/code-snippet}}
   {{/inline}}
 {{/page}}

--- a/docs/components/header/index.hbs
+++ b/docs/components/header/index.hbs
@@ -213,11 +213,7 @@ toc:
 
     {{> example path="/components/header/demos/container.html"}}
 
-    {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/container"}}
-        {{{.}}}
-      {{/get}}
-    {{/code-snippet}}
+    {{#code-snippet "html"}}{{#get snippets "/components/header/snippets/container"}}{{{this}}}{{/get}}{{/code-snippet}}
 
     <p>If you're building a web app that needs to have full-width content,
     consider making the header expand to the full width too. Use
@@ -225,11 +221,7 @@ toc:
 
     {{> example path="/components/header/demos/container-fluid.html"}}
 
-    {{#code-snippet "html"}}
-      {{#get snippets "/components/header/snippets/container-fluid"}}
-        {{{.}}}
-      {{/get}}
-    {{/code-snippet}}
+    {{#code-snippet "html"}}{{#get snippets "/components/header/snippets/container-fluid"}}{{{this}}}{{/get}}{{/code-snippet}}
 
     <h2 id="appearance" class="docs-h3">Appearance</h2>
 

--- a/lib/handlebars-code-snippet.js
+++ b/lib/handlebars-code-snippet.js
@@ -1,5 +1,6 @@
 import handlebars from 'handlebars'
 import hljs from 'highlight.js'
+import os from 'os'
 
 function codeSnippet(language, opts) {
   if (!opts) {
@@ -10,7 +11,7 @@ function codeSnippet(language, opts) {
   let markup = opts.fn(this)
 
   // Split the markup into lines, to do some cleanup magic
-  let lines = markup.split('\n')
+  let lines = markup.split(os.EOL)
 
   // Remove leading lines that are empty
   // Usecase: If the snippet is from a hbs-template with frontmatter it'll
@@ -41,7 +42,7 @@ function codeSnippet(language, opts) {
     : line))
 
   // Combine all lines again
-  markup = lines.join('\n')
+  markup = lines.join(os.EOL)
 
   const highlighted = hljs.highlight(language, markup)
 


### PR DESCRIPTION
Was looking so far, but it was so close...
On Windows a new line is added to the code snippets after metalsmith deals with the frontmatter. Leading blanks from the handlebars template which includes the snippet are then added to that line which will be removed again in the code-snippet helper.
On Linux this newline will not be added, so blanks will be added directly to the first line of actual content which leads to the unwanted behavior.