### PR TITLE
Use unpkg.com as CDN

### DIFF
--- a/docs/getting-started/downloads/index.hbs
+++ b/docs/getting-started/downloads/index.hbs
@@ -14,8 +14,6 @@ toc:
   - title: Package managers
     slug: package-managers
 fontUrl: https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700
-cssUrl: https://design.axa.com/toolkit/dist/all.css
-jsUrl: https://design.axa.com/toolkit/dist/all.js
 autoprefixerUrl: https://github.com/postcss/autoprefixer
 flexbugsUrl: https://github.com/luisrudge/postcss-flexbugs-fixes
 ---
@@ -63,17 +61,10 @@ flexbugsUrl: https://github.com/luisrudge/postcss-flexbugs-fixes
     <p>Skip the download and use our CDN to deliver
     the compiled CSS and JS to your project.</p>
 
-    <div class="alert alert-danger" role="alert">
-      <p><strong>Watch out!</strong> Our CDN isn't ready yet,
-      which is why the URLs you'll find below aren't properly
-      versioned and highly available. To use the AXA Web Toolkit productively,
-      choose an alternative download method.</p>
-    </div>
-
     {{#code-snippet "html"}}
       <link rel="stylesheet" href="{{{fontUrl}}}" crossorigin="anonymous">
-      <link rel="stylesheet" href="{{{cssUrl}}}" crossorigin="anonymous">
-      <script src="{{{jsUrl}}}" crossorigin="anonymous"></script>
+      <link rel="stylesheet" href="{{replace package.cdnCss '{tag}' package.version}}" crossorigin="anonymous">
+      <script src="{{replace package.cdnJs '{tag}' package.version}}" crossorigin="anonymous"></script>
     {{/code-snippet}}
 
     <h2 id="package-managers" class="docs-h3">Package managers</h2>

--- a/docs/getting-started/index.hbs
+++ b/docs/getting-started/index.hbs
@@ -4,8 +4,6 @@ nav: side/getting-started/introduction
 order: 1
 lunr: true
 fontUrl: https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700
-cssUrl: https://design.axa.com/toolkit/dist/all.css
-jsUrl: https://design.axa.com/toolkit/dist/all.js
 metaExplanationUrl: https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do
 toc:
   - title: Quick Start
@@ -44,22 +42,13 @@ toc:
     <a href="{{relative '/getting-started/downloads/'}}">Check out
     the downloads page.</a></p>
 
-    <div class="alert alert-danger" role="alert">
-      <p><strong>Watch out!</strong> Our CDN isn't ready yet,
-      which is why the URLs you'll find below aren't properly
-      versioned and highly available. To use the AXA Web Toolkit productively,
-      choose an
-      <a href="{{relative '/getting-started/downloads/'}}">alternative
-      download method</a>.</p>
-    </div>
-
     <p>Copy-paste the stylesheet <code>&lt;link&gt;</code> of the
     Web Toolkit and the fonts into your <code>&lt;head&gt;</code>
     before all other stylesheets to load our CSS.</p>
 
     {{#code-snippet "html"}}
       <link rel="stylesheet" href="{{{fontUrl}}}" crossorigin="anonymous">
-      <link rel="stylesheet" href="{{{cssUrl}}}" crossorigin="anonymous">
+      <link rel="stylesheet" href="{{replace package.cdnCss '{tag}' package.version}}" crossorigin="anonymous">
     {{/code-snippet}}
 
     <p>Add our JavaScript plugins and jQuery near the end of your pages,
@@ -67,7 +56,7 @@ toc:
     Be sure to place jQuery first, as our code depends on them.</p>
 
     {{#code-snippet "html"}}
-      <script src="{{{jsUrl}}}" crossorigin="anonymous"></script>
+      <script src="{{replace package.cdnJs '{tag}' package.version}}" crossorigin="anonymous"></script>
     {{/code-snippet}}
 
     <p>And that's it—you're on your way to a fully
@@ -101,14 +90,14 @@ toc:
 
         <!-- Fonts first, then the AXA Web Toolkit CSS. -->
         <link rel="stylesheet" href="{{{fontUrl}}}" crossorigin="anonymous">
-        <link rel="stylesheet" href="{{{cssUrl}}}" crossorigin="anonymous">
+        <link rel="stylesheet" href="{{replace package.cdnCss '{tag}' package.version}}" crossorigin="anonymous">
       </head>
       <body>
         <h1>Hello, world!</h1>
 
         <!-- jQuery first, then the AXA Web Toolkit JS. -->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" crossorigin="anonymous"></script>
-        <script src="{{{jsUrl}}}" crossorigin="anonymous"></script>
+        <script src="{{replace package.cdnJs '{tag}' package.version}}" crossorigin="anonymous"></script>
       </body>
       </html>
     {{/code-snippet}}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "distArchive": "https://github.com/axa-group/web-toolkit/releases/download/v{tag}/web-toolkit-v{tag}-dist.zip",
   "sourceArchive": "https://github.com/axa-group/web-toolkit/archive/{tag}.zip",
   "npmjsPackage": "https://www.npmjs.com/package/@axa/web-toolkit",
+  "cdnCss": "https://unpkg.com/@axa/web-toolkit@{tag}/dist/bundles/all.css",
+  "cdnJs": "https://unpkg.com/@axa/web-toolkit@{tag}/dist/bundles/all.js",
   "keywords": [
     "axa",
     "insurance",


### PR DESCRIPTION
Fixes #77!

* [x] We're getting rid of this annoying alert:

  <img width="773" alt="screen shot 2016-11-23 at 21 34 22" src="https://cloud.githubusercontent.com/assets/198988/20577926/ef9dbd92-b1c4-11e6-99c2-c2bb0bf59cba.png">

* [x] And now use `unpkg.com` as our CDN (thanks to @romariclaurent for the suggestion)
  
  ![screen shot 2016-11-23 at 21 35 22](https://cloud.githubusercontent.com/assets/198988/20577948/1167db60-b1c5-11e6-986a-a2affffb5cbb.png)

* [x] Adjusted the *Getting started* and *Downloads* pages