### PR TITLE
Fix the source code download link

### DIFF
--- a/docs/getting-started/browser-not-supported/index.hbs
+++ b/docs/getting-started/browser-not-supported/index.hbs
@@ -2,7 +2,7 @@
 title: Browser not supported page
 description: Notify users of old browsers to upgrade in order to enjoy your app.
 nav: side/getting-started/browser-not-supported
-order: 3
+order: 4
 lunr: true
 toc:
   - title: Redirect
@@ -25,7 +25,7 @@ toc:
       There are two good ways to show users of old IE versions (version <= 9).
       Both are based on IE's conditional comments features.
     </p>
-    
+
     {{> table-of-contents data=toc}}
 
     <h2 id="redirect" class="docs-h3">Redirect</h2>

--- a/docs/getting-started/colors.hbs
+++ b/docs/getting-started/colors.hbs
@@ -2,7 +2,7 @@
 title: Colors
 description: Overview over our color variables.
 nav: side/getting-started/colors
-order: 2
+order: 3
 ---
 {{#> page}}
   {{#*inline "content"}}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepageWebGuidelines": "https://design.axa.com/introduction",
   "releasesUrl": "https://github.com/axa-group/web-toolkit/releases",
   "distArchive": "https://github.com/axa-group/web-toolkit/releases/download/v{tag}/web-toolkit-v{tag}-dist.zip",
-  "sourceArchive": "https://github.com/axa-group/web-toolkit/archive/{tag}.zip",
+  "sourceArchive": "https://github.com/axa-group/web-toolkit/archive/v{tag}.zip",
   "bootstrapDocs": "http://bootstrapdocs.com/v3.3.6/docs/",
   "npmjsPackage": "https://www.npmjs.com/package/@axa/web-toolkit",
   "cdnCss": "https://unpkg.com/@axa/web-toolkit@{tag}/dist/bundles/all.css",


### PR DESCRIPTION
[Didn't work](https://design.axa.com/toolkit/getting-started/downloads/#source-files) due to a missing `v` in the link.

Also using this pr to move the *Downloads* page to the second position again.
![screen shot 2016-11-28 at 10 37 19](https://cloud.githubusercontent.com/assets/198988/20663135/b8be9c66-b556-11e6-986a-29b1a90bf720.png)
