### PR TITLE
Fix the example resizer transition

### DIFF
--- a/docs/scss/_example.scss
+++ b/docs/scss/_example.scss
@@ -60,7 +60,7 @@
   max-width: 100%;
   margin: 0 auto;
 
-  transition: max-width $transition-normal $transition-ease;
+  transition: width $transition-normal $transition-ease;
 
   border: none;
   background: $color-white;


### PR DESCRIPTION
The transition broke due to the past change from `max-width` to `width`.
Now adjusting the forgotten `transition` property, too.