### PR TITLE
Add full code snippet in header example

### DIFF
--- a/docs/components/header/index.hbs
+++ b/docs/components/header/index.hbs
@@ -35,16 +35,7 @@ toc:
 
     {{> example path="/components/header/demos/standard-header.html"}}
 
-    {{#code-snippet "html"}}
-      <header class="header">
-        <div class="header-meta hidden-md-down">
-          <!-- items for the upper header part -->
-        </div>
-        <div class="header-main">
-          <!-- items for the main header part, e.g. brand, burger-menu, search, main-nav, main-action -->
-        </div>
-      </header>
-    {{/code-snippet}}
+    {{#code-snippet "html"}}{{#get snippets "/components/header/snippets/standard-header"}}{{{this}}}{{/get}}{{/code-snippet}}
 
     <h2 id="supported-content" class="docs-h3">Supported Content</h2>
 

--- a/docs/components/header/snippets/standard-header.hbs
+++ b/docs/components/header/snippets/standard-header.hbs
@@ -3,9 +3,9 @@ title: Standard Header
 layout: demo.hbs
 ---
 <header class="header">
-  <div class="header-meta hidden-md-down">
+  <div class="header-meta hidden-sm-down">
     <div class="container-fluid">
-      <nav class="header-meta-menu float-xs-right hidden-md-down">
+      <nav class="header-meta-menu float-xs-right">
         <ul class="header-meta-menu-list">
           <li class="header-meta-menu-item">
             <a href="#" class="header-meta-menu-link">Individuals</a>
@@ -27,7 +27,7 @@ layout: demo.hbs
         <img class="header-brand-image" src="{{relative '/images/axa.svg'}}" />
       </a>
 
-      <a  href="#"class="header-burger float-xs-right hidden-lg-up">
+      <a  href="#"class="header-burger float-xs-right hidden-md-up">
         <span class="header-burger-line"></span>
       </a>
 
@@ -45,7 +45,7 @@ layout: demo.hbs
         <a href="#" class="btn btn-default">File a Claim</a>
       </div>
 
-      <nav id="overviewNav" class="nav float-xs-right hidden-md-down" data-fade="search" data-target="#overviewSearch" data-in="fade-in-delayed-xs-up" data-out="fade-out-xs-up">
+      <nav id="overviewNav" class="nav float-xs-right hidden-sm-down" data-fade="search" data-target="#overviewSearch" data-in="fade-in-delayed-xs-up" data-out="fade-out-xs-up">
         <ul class="nav-list">
           <li class="nav-item">
             <a href="#" class="nav-link">Web Guidelines</a>

--- a/docs/scss/_code-snippet.scss
+++ b/docs/scss/_code-snippet.scss
@@ -16,6 +16,7 @@
     padding: 0;
     border: none;
     background-color: transparent;
+    word-wrap: normal;
 
     code {
       white-space: nowrap;


### PR DESCRIPTION
This pr introduces the full code snippet to the header example page. #99

Also, I'm preventing line breaks, which makes the code snippets much shorter (adding horizontal scrolling though).

Additionally, the complete header now already appears on the `md` viewport.