### PR TITLE
Make the ghost buttons transparent

### DIFF
--- a/docs/components/banner/index.hbs
+++ b/docs/components/banner/index.hbs
@@ -36,7 +36,7 @@ toc:
             <p class="banner-title">Title</p>
             <p class="banner-lead">A key message which makes your topic interesting to your customers.</p>
             <div class="banner-actions">
-              <a href="#" class="banner-action btn btn-ghost btn-lg">Call to action</a>
+              <a href="#" class="banner-action btn btn-ghost btn-ghost-white btn-lg">Call to action</a>
             </div>
           </div>
         </div>

--- a/docs/components/banner/snippets/banner.hbs
+++ b/docs/components/banner/snippets/banner.hbs
@@ -20,7 +20,7 @@ banner1200: https://cloud.githubusercontent.com/assets/198988/20709927/4694e9fa-
       <p class="banner-title">Title</p>
       <p class="banner-lead">A key message which makes your topic interesting to your customers.</p>
       <div class="banner-actions">
-        <a href="#" class="banner-action btn btn-ghost btn-lg">Call to action</a>
+        <a href="#" class="banner-action btn btn-ghost btn-ghost-white btn-lg">Call to action</a>
       </div>
     </div>
   </div>

--- a/docs/templates/axa-com/index.hbs
+++ b/docs/templates/axa-com/index.hbs
@@ -101,7 +101,7 @@ order: 1
           <p class="banner-title">Title of an article</p>
           <p class="banner-lead">A key message which makes your topic interesting to your customers.</p>
           <div class="banner-actions">
-            <a href="#" class="banner-action btn btn-ghost btn-lg">Read more</a>
+            <a href="#" class="banner-action btn btn-ghost btn-ghost-white btn-lg">Read more</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This make the ghost buttons transparent in the `banner` docs and in the axa.com template page.

I wouldn't try to solve this in this pr, but isn't the ghost button supposed to have a transparent background even without the `btn-ghost-white` modifier?

Having to specify `btn btn-ghost btn-ghost-white` seems a little bit too much to get a standard and very common kind of button.