### PR TITLE
Use button instead of anchor for example buttons

### DIFF
--- a/docs/_partials/example.hbs
+++ b/docs/_partials/example.hbs
@@ -5,10 +5,10 @@
     {{#if disableMd}}data-example-disable-md="true"{{/if}}
     {{#if disableLg}}data-example-disable-lg="true"{{/if}}>
   <div class="docs-example-devices-list">
-    <a class="docs-example-device" data-example-xs>xs</a>
-    <a class="docs-example-device" data-example-sm>sm</a>
-    <a class="docs-example-device" data-example-md>md</a>
-    <a class="docs-example-device" data-example-lg>lg</a>
+    <button class="docs-example-device" data-example-xs>xs</button>
+    <button class="docs-example-device" data-example-sm>sm</button>
+    <button class="docs-example-device" data-example-md>md</button>
+    <button class="docs-example-device" data-example-lg>lg</button>
   </div>
   <div class="docs-example-content">
     <iframe class="docs-example-iframe"

--- a/docs/scss/_example.scss
+++ b/docs/scss/_example.scss
@@ -29,7 +29,9 @@
 
   transition: background $transition-slow $transition-ease, color $transition-slow $transition-ease;
 
+  border: none;
   border-radius: .25rem;
+  background-color: transparent;
   color: $color-mineshaft;
   text-align: center;
   cursor: pointer;


### PR DESCRIPTION
This is to prevent the behavior when we migrate to Bootstrap v4, which makes anchors without a `href` look invalid.