### PR TITLE
Ignore yarn.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ npm-debug.log
 WebEssentials-Settings.json
 phantomjs
 screenshots/
+
+# yarn
+yarn.lock


### PR DESCRIPTION
I know it's not supposed to be ignored, but let's think about it when our dependencies are a little bit more stable.