### PR TITLE
Make a more robust version of button hover animation

### DIFF
--- a/scss/style/mixins/_btn.scss
+++ b/scss/style/mixins/_btn.scss
@@ -33,18 +33,17 @@
 
   // animation
   &:after {
+    content: "";
     position: absolute;
+    height: calc(100% + 4px);
+    width: 0;
     top: 50%;
     left: 50%;
-    width: 0;
-    height: 530px;
-    transform: translate(-50%,-50%) rotate(45deg);
-    transform: translate3d(-50%,-50%, 0) rotate(45deg);
-    transition: width 0.3s, opacity 0.3s;
+    transform: translate(-50%, -50%) skew(-45deg);
     background: $color;
-    content: '';
-    opacity: 0;
+    transition: width 0.3s, opacity 0.3s;
     z-index: -1;
+    opacity: 0;
     backface-visibility: hidden;
   }
 
@@ -52,7 +51,7 @@
   &:active,
   &:focus {
     &:after {
-      width: 100%;
+      width: calc(100% + 6rem);
       opacity: 1;
     }
   }

--- a/scss/style/mixins/_btn.scss
+++ b/scss/style/mixins/_btn.scss
@@ -40,6 +40,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%) skew(-45deg);
+    transform: translate3d(-50%, -50%, 0) skew(-45deg);
     background: $color;
     transition: width 0.3s, opacity 0.3s;
     z-index: -1;


### PR DESCRIPTION
In some cases, the current implementation of buttons hover effect does not cover the corners.
In this version, the :after element is smaller (which should benefit animation performance) and should always cover the whole button.