### PR TITLE
Fix alert height rule cropping buttons

### DIFF
--- a/scss/style/_alerts.scss
+++ b/scss/style/_alerts.scss
@@ -7,10 +7,6 @@
   color: $color-white;
   text-transform: uppercase;
 
-  @include media-breakpoint-up(xl) {
-    height: 48px;
-  }
-
   @include media-breakpoint-down(xs) {
     flex-wrap: wrap;
   }
@@ -22,8 +18,8 @@
   }
 }
 
-.top-content-bar-btn {
-  margin-left: 20px;
+.top-content-bar-btn.btn { // Add .btn class to raise priority. Otherwise, standard styles are applied
+  margin: -.25rem 0 -.25rem 20px;
 }
 
 .top-content-bar--corporate {


### PR DESCRIPTION
The fixed height on Alert styles crops the button on top, in XL mode.
In other modes, the margin standard margin bottom on the button makes it look offset to the top.

![alerts_ _axa_web_toolkit](https://user-images.githubusercontent.com/393608/33854771-24ef0a56-dec3-11e7-885d-9ae4f84c2819.png)
