### PR TITLE
Add Secondary Palette in variables

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -193,6 +193,23 @@ $color-monte-carlo: #7ed2d2;
 $color-dark-orchild: #bc30c1;
 $color-nero: #1a1a1a;
 
+/// Used as secondary background color
+/// @title Igloo
+/// @color Secondary Background Colors
+$color-igloo: #b5d0ee;
+$color-cotton-candy: #fad6de;
+$color-azalea: #f1afc6;
+$color-aqua-green: #9fd9b4;
+$color-logan: #9190ac;
+$color-greyjoy: #9fbeaf;
+$color-viridian-green: #668980;
+$color-pacific: #00adc6;
+$color-teal: #027180;
+$color-acid: #f0ff93;
+$color-dune: #fcd385;
+$color-apache: #ddbe65;
+$color-tosca: #914146;
+
 //----- Override bootstrap colors
 
 $brand-primary:         $color-indigo !default;


### PR DESCRIPTION
Hi,
While reading [guidelines](https://design.axa.com/web-guidelines/color#palettes) on color palettes, I noticed the "Secondary Palette" wasn't included in the `_variables.scss` file, so I added it.